### PR TITLE
Fix crash, when trying to convert maps that have more than 3 arguments

### DIFF
--- a/fnf_converter.py
+++ b/fnf_converter.py
@@ -211,7 +211,7 @@ class Fnf_chart:
         else:  # idk how it's possible to finish here
             notes_list = []
 
-        notes_list.sort()  # sort the notes by offset order (using the index 0)
+        notes_list.sort(key=lambda note: ' '.join(map(str, note[:3])))  # sort the notes by offset order (using the index 0) and ignore any argument, if argument count exceeds 3
 
         # convert to osu notes
         note_type = 0  # used to determinate the 4th parameter of a hitobject. 1=normal note, 128=long note, +4=new combo


### PR DESCRIPTION
Issue #7 which I randomly stumbled by. I am unsure wether my small bug fix is okay or not, but it seems to have worked for me. And as I dont have much time today, its the best I could do rq.

(I did try it with the same song and map from the issue and it worked, and a version bump is not necessary, since it was solved in version 1.1.2, so its safe to merge, and simply update the release file)